### PR TITLE
Add length(), lengthT() and 'size' equivalents

### DIFF
--- a/astring.h
+++ b/astring.h
@@ -30,6 +30,15 @@ public:
     Astr(const char* string);
     
     ~Astr();
+    
+    int length(){ return *m_length; }
+
+    // Returns length including terminator
+    int lengthT(){ return *m_lengthT; }
+
+    // Synonyms for length
+    int size(){ return length(); }
+    int sizeT(){ return lengthT(); }
 };
 
 #endif

--- a/examples/Test/Test.ino
+++ b/examples/Test/Test.ino
@@ -11,9 +11,11 @@ void setup() {
 
 	Serial.begin(9600);
 
-	// charAt();
 	Astr s1 = Astr("Hello, World");
 
+	// Length
+	testCond("length()", s1.length() == 12);
+	testCond("lengthT()", s1.lengthT() == 13);
 }
 
 void loop() {}


### PR DESCRIPTION
> Note: Fulfills issue #3 

Adds the following Astr class function members:
- length()
- lengthT()
- size()
- sizeT()

Details:
- the "T" suffix indicates that the null-terminator is included in the returned
- size() and sizeT() are equivalents and are defined in terms of length*()
- length was chosen as the preferred names because a string is, for example, "5 characters long," while size may be interpreted as the number of bytes taken by the string